### PR TITLE
修复开机启动 PlayService 时调用 getCurrentPlayingMusic 方法导致的数组下标越界异常

### DIFF
--- a/player/src/main/java/com/kunminx/player/PlayingInfoManager.java
+++ b/player/src/main/java/com/kunminx/player/PlayingInfoManager.java
@@ -126,6 +126,9 @@ public class PlayingInfoManager<B extends BaseAlbumItem, M extends BaseMusicItem
     }
 
     public M getCurrentPlayingMusic() {
+        if (getPlayingList().isEmpty()) {
+            return null;
+        }
         return getPlayingList().get(mPlayIndex);
     }
 


### PR DESCRIPTION
问题: 模拟器开机后 crash 异常
运行环境: 模拟器 Pixel 2 Android 7.0
操作步骤: 
安装打开应用之后重启设备(adb reboot)
奔溃日志: 
08-04 06:28:55.174 2270-2270/com.kunminx.puremusic D/PlayerReceiver: Intent { act=android.media.AUDIO_BECOMING_NOISY flg=0x14000010 cmp=com.kunminx.puremusic/.player.notification.PlayerReceiver }
08-04 06:28:55.281 2270-2270/com.kunminx.puremusic E/MediaPlayer: pause called in state 1
08-04 06:28:55.281 2270-2270/com.kunminx.puremusic E/MediaPlayer: error (-38, 0)
08-04 06:28:55.297 2270-2270/com.kunminx.puremusic E/MediaPlayer: Error (-38,0)
08-04 06:28:55.304 2270-2270/com.kunminx.puremusic D/PlayService: Intent { cmp=com.kunminx.puremusic/.player.notification.PlayerService }
08-04 06:28:55.307 2270-2270/com.kunminx.puremusic D/AndroidRuntime: Shutting down VM
    
    
    --------- beginning of crash
08-04 06:28:55.308 2270-2270/com.kunminx.puremusic E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.kunminx.puremusic, PID: 2270
    java.lang.RuntimeException: Unable to start service com.kunminx.puremusic.player.notification.PlayerService@6ecae11 with Intent { cmp=com.kunminx.puremusic/.player.notification.PlayerService }: java.lang.IndexOutOfBoundsException: Invalid index 0, size is 0
        at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:3027)
        at android.app.ActivityThread.-wrap17(ActivityThread.java)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1442)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:148)
        at android.app.ActivityThread.main(ActivityThread.java:5417)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
     Caused by: java.lang.IndexOutOfBoundsException: Invalid index 0, size is 0
        at java.util.ArrayList.throwIndexOutOfBoundsException(ArrayList.java:255)
        at java.util.ArrayList.get(ArrayList.java:308)
        at com.kunminx.player.PlayingInfoManager.getCurrentPlayingMusic(PlayingInfoManager.java:129)
        at com.kunminx.player.PlayerController.getCurrentPlayingMusic(PlayerController.java:330)
        at com.kunminx.puremusic.player.PlayerManager.getCurrentPlayingMusic(PlayerManager.java:204)
        at com.kunminx.puremusic.player.notification.PlayerService.onStartCommand(PlayerService.java:94)
        at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:3010)
        at android.app.ActivityThread.-wrap17(ActivityThread.java) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1442) 
        at android.os.Handler.dispatchMessage(Handler.java:102) 
        at android.os.Looper.loop(Looper.java:148) 
        at android.app.ActivityThread.main(ActivityThread.java:5417) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616) 

崩溃原因:
开机后应用监听到 android.media.AUDIO_BECOMING_NOISY 广播, 触发 PlayService 的 onStartCommand 回调, 回调中触发了 getCurrentPlayingMusic 方法, 但此时并未添加播放的音乐

08-04 06:16:04.305 2225-2225/com.kunminx.puremusic D/PlayerReceiver: Intent { act=android.media.AUDIO_BECOMING_NOISY flg=0x14000010 cmp=com.kunminx.puremusic/.player.notification.PlayerReceiver }
08-04 06:16:04.351 2225-2225/com.kunminx.puremusic D/PlayService: Intent { cmp=com.kunminx.puremusic/.player.notification.PlayerService }